### PR TITLE
🔔 Merge Request: feature/QUAR-68-final-cleanup to dev

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { ToastContainer } from 'react-toastify';
 import { CookiesProvider } from 'react-cookie';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import accessTokenInterceptor from './common/utils/session.ts';
+import { accessTokenInterceptor, useRefreshTokenInterceptor } from './common/utils/session.ts';
 import AppRouter from './router.tsx';
 import './index.scss';
 import 'react-toastify/dist/ReactToastify.css';
@@ -10,6 +10,7 @@ const queryClient = new QueryClient();
 
 function App() {
   accessTokenInterceptor();
+  useRefreshTokenInterceptor();
   return (
     <>
       <ToastContainer position="top-center" autoClose={3000} pauseOnHover />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { ToastContainer } from 'react-toastify';
 import { CookiesProvider } from 'react-cookie';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { accessTokenInterceptor, useRefreshTokenInterceptor } from './common/utils/session.ts';
+import { accessTokenInterceptor } from './common/utils/session.ts';
 import AppRouter from './router.tsx';
 import './index.scss';
 import 'react-toastify/dist/ReactToastify.css';
@@ -10,7 +10,7 @@ const queryClient = new QueryClient();
 
 function App() {
   accessTokenInterceptor();
-  useRefreshTokenInterceptor();
+
   return (
     <>
       <ToastContainer position="top-center" autoClose={3000} pauseOnHover />

--- a/src/api/API/API.ts
+++ b/src/api/API/API.ts
@@ -97,9 +97,10 @@ const deleteCalendarData = (certificationId: number) => {
 };
 
 // 자격증 조회
-const getCertData = (categoryId: number, page: number, pageSize: number) => {
+const getCertData = (isMain: boolean, categoryId: number, page: number, pageSize: number) => {
   return async (): Promise<ICertList> => {
     const params = {
+      isMain: isMain,
       categoryId: categoryId,
       page: page,
       pageSize: pageSize,

--- a/src/api/API/API.ts
+++ b/src/api/API/API.ts
@@ -110,10 +110,12 @@ const getCertData = (categoryId: number, page: number, pageSize: number) => {
 };
 
 // 자격증 검색
-const getSearchCertData = (name?: string) => {
+const getSearchCertData = (name: string, page: number, pageSize: number) => {
   return async (): Promise<ICertSearchList> => {
     const params = {
       name: name,
+      page: page,
+      pageSize: pageSize,
     };
     const response = await axios.get(`${BASE_URL}/${CERTIFICATIONS}/search`, { params });
     return response.data;

--- a/src/api/queries/useCertQuery.ts
+++ b/src/api/queries/useCertQuery.ts
@@ -15,11 +15,10 @@ const useGetCert = (categoryId: number, page: number, pageSize: number) => {
   });
 };
 
-const useGetSearchCert = (name?: string) => {
+const useGetSearchCert = (name: string, page: number, pageSize: number) => {
   return useQuery({
-    queryKey: [certQueryKey.search, name],
-    queryFn: getSearchCertData(name),
-    enabled: !!name,
+    queryKey: [certQueryKey.search, name, page],
+    queryFn: getSearchCertData(name, page, pageSize),
   });
 };
 

--- a/src/api/queries/useCertQuery.ts
+++ b/src/api/queries/useCertQuery.ts
@@ -7,10 +7,10 @@ import {
   getSearchCertData,
 } from '../API/API.ts';
 
-const useGetCert = (categoryId: number, page: number, pageSize: number) => {
+const useGetCert = (isMain: boolean, categoryId: number, page: number, pageSize: number) => {
   return useQuery({
     queryKey: [certQueryKey.get, categoryId, page],
-    queryFn: getCertData(categoryId, page, pageSize),
+    queryFn: getCertData(isMain, categoryId, page, pageSize),
     enabled: !!categoryId,
   });
 };

--- a/src/common/Layouts/Header.tsx
+++ b/src/common/Layouts/Header.tsx
@@ -1,8 +1,17 @@
 import { useMoveToPage } from '@hook/page.ts';
+import useAuthService from '@feature/Auth/useAuthService.ts';
+import authStore from '@store/auth/authStore.ts';
 import './style/Header.scss';
 
 const Header = () => {
+  const { accessToken } = authStore();
+  const { logoutService } = useAuthService();
   const moveToPage = useMoveToPage();
+
+  const onClickLogout = async () => {
+    await logoutService();
+    moveToPage('/');
+  };
 
   return (
     <div className="header">
@@ -11,29 +20,37 @@ const Header = () => {
           자격저격
         </div>
         <div className="header-button-group">
-          <button className="my-calendar-button" onClick={() => moveToPage('/myCalendar')}>
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={1.5}
-              stroke="currentColor"
-              className="my-calendar-button-icon"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"
-              />
-            </svg>
-            내 캘린더
-          </button>
-          <button className="login-button" onClick={() => moveToPage('/login')}>
-            로그인
-          </button>
-          <button className="myPage-button" onClick={() => moveToPage('/myPage')}>
-            마이페이지
-          </button>
+          {!accessToken ? (
+            <button className="login-button" onClick={() => moveToPage('/login')}>
+              로그인
+            </button>
+          ) : (
+            <>
+              <button className="my-calendar-button" onClick={() => moveToPage('/myCalendar')}>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={1.5}
+                  stroke="currentColor"
+                  className="my-calendar-button-icon"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"
+                  />
+                </svg>
+                내 캘린더
+              </button>
+              <button className="myPage-button" onClick={() => moveToPage('/myPage')}>
+                마이페이지
+              </button>
+              <button className="logout-button" onClick={onClickLogout}>
+                로그아웃
+              </button>
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/common/Layouts/Header.tsx
+++ b/src/common/Layouts/Header.tsx
@@ -1,10 +1,10 @@
 import { useMoveToPage } from '@hook/page.ts';
 import useAuthService from '@feature/Auth/useAuthService.ts';
-import authStore from '@store/auth/authStore.ts';
+import { accessTokenStore } from '@store/auth/authStore.ts';
 import './style/Header.scss';
 
 const Header = () => {
-  const { accessToken } = authStore();
+  const { accessToken } = accessTokenStore();
   const { logoutService } = useAuthService();
   const moveToPage = useMoveToPage();
 

--- a/src/common/Layouts/style/Header.scss
+++ b/src/common/Layouts/style/Header.scss
@@ -35,13 +35,9 @@
         }
       }
 
-      .login-button {
-        background: none;
-        border: none;
-        cursor: pointer;
-      }
-
-      .myPage-button {
+      .login-button,
+      .myPage-button,
+      .logout-button {
         background: none;
         border: none;
         cursor: pointer;

--- a/src/common/store/auth/authStore.ts
+++ b/src/common/store/auth/authStore.ts
@@ -1,8 +1,8 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
-import IAuthType from './authType.ts';
+import { IAccessTokenType, IRefreshTokenType } from './authType.ts';
 
-const authStore = create<IAuthType>()(
+const accessTokenStore = create<IAccessTokenType>()(
   persist(
     (set) => ({
       accessToken: '',
@@ -22,4 +22,16 @@ const authStore = create<IAuthType>()(
   )
 );
 
-export default authStore;
+const refreshTokenStore = create<IRefreshTokenType>((set) => ({
+  refreshToken: '',
+  setRefreshToken: (refreshToken: string) =>
+    set({
+      refreshToken: refreshToken,
+    }),
+  clearRefreshToken: () =>
+    set({
+      refreshToken: '',
+    }),
+}));
+
+export { accessTokenStore, refreshTokenStore };

--- a/src/common/store/auth/authType.ts
+++ b/src/common/store/auth/authType.ts
@@ -1,7 +1,13 @@
-interface IAuthType {
+interface IAccessTokenType {
   accessToken: string;
   setAccessToken: (accessToken: string) => void;
   clearAccessToken: () => void;
 }
 
-export default IAuthType;
+interface IRefreshTokenType {
+  refreshToken: string;
+  setRefreshToken: (refreshToken: string) => void;
+  clearRefreshToken: () => void;
+}
+
+export type { IAccessTokenType, IRefreshTokenType };

--- a/src/common/store/certification/certStore.ts
+++ b/src/common/store/certification/certStore.ts
@@ -1,9 +1,14 @@
 import { create } from 'zustand';
-import ISearchWordType from './certType';
+import { ISearchWordType, IIsMainCategoryType } from './certType';
 
-const certStore = create<ISearchWordType>((set) => ({
+const searchWordStore = create<ISearchWordType>((set) => ({
   searchWord: '',
   setSearchWord: (searchWord) => set({ searchWord }),
 }));
 
-export default certStore;
+const isMainCategoryStore = create<IIsMainCategoryType>((set) => ({
+  isMainCategory: true,
+  setIsMainCategory: (isMainCategory) => set({ isMainCategory }),
+}));
+
+export { searchWordStore, isMainCategoryStore };

--- a/src/common/store/certification/certType.ts
+++ b/src/common/store/certification/certType.ts
@@ -3,4 +3,9 @@ interface ISearchWordType {
   setSearchWord: (searchWord: string) => void;
 }
 
-export default ISearchWordType;
+interface IIsMainCategoryType {
+  isMainCategory: boolean;
+  setIsMainCategory: (isMainCategory: boolean) => void;
+}
+
+export type { ISearchWordType, IIsMainCategoryType };

--- a/src/common/store/page/pageStore.ts
+++ b/src/common/store/page/pageStore.ts
@@ -1,9 +1,14 @@
 import { create } from 'zustand';
-import IPageType from './pageType';
+import { IPageType, ISearchedPageType } from './pageType';
 
 const pageStore = create<IPageType>((set) => ({
   page: 1,
   setPage: (page) => set({ page }),
 }));
 
-export default pageStore;
+const searchedPageStore = create<ISearchedPageType>((set) => ({
+  searchedPage: 1,
+  setSearchedPage: (searchedPage) => set({ searchedPage }),
+}));
+
+export { pageStore, searchedPageStore };

--- a/src/common/store/page/pageType.ts
+++ b/src/common/store/page/pageType.ts
@@ -3,4 +3,9 @@ interface IPageType {
   setPage: (page: number) => void;
 }
 
-export default IPageType;
+interface ISearchedPageType {
+  searchedPage: number;
+  setSearchedPage: (page: number) => void;
+}
+
+export type { IPageType, ISearchedPageType };

--- a/src/common/utils/session.ts
+++ b/src/common/utils/session.ts
@@ -1,12 +1,12 @@
 import axios from 'axios';
-import authStore from '@store/auth/authStore.ts';
+import { accessTokenStore } from '@store/auth/authStore.ts';
 import useAuthService from '@feature/Auth/useAuthService';
 
 const accessTokenInterceptor = () => {
   axios.interceptors.request.use(
     (config) => {
       if (config.url?.includes('/api/v1')) {
-        const { accessToken } = authStore.getState();
+        const { accessToken } = accessTokenStore.getState();
         config.headers.Authorization = `Bearer ${accessToken}`;
         config.headers.accept = 'application/json';
       }

--- a/src/common/utils/session.ts
+++ b/src/common/utils/session.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
-import authStore from '../store/auth/authStore';
+import authStore from '@store/auth/authStore.ts';
+import useAuthService from '@feature/Auth/useAuthService';
 
 const accessTokenInterceptor = () => {
   axios.interceptors.request.use(
@@ -17,4 +18,18 @@ const accessTokenInterceptor = () => {
   );
 };
 
-export default accessTokenInterceptor;
+const useRefreshTokenInterceptor = () => {
+  const { refreshService } = useAuthService();
+  axios.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      if (error.response?.status === 401 && !error.config._retry) {
+        error.config._retry = true;
+        refreshService();
+      }
+      return Promise.reject(error);
+    }
+  );
+};
+
+export { accessTokenInterceptor, useRefreshTokenInterceptor };

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -1,38 +1,51 @@
 import ArrowLeft from '@icon/icon-arrow-left.svg?react';
 import ArrowRight from '@icon/icon-arrow-right.svg?react';
-import pageStore from '@store/page/pageStore';
+import { pageStore, searchedPageStore } from '@store/page/pageStore';
 import './style/pagination.scss';
 
-const Pagination = ({ certTotalPage }: { certTotalPage: number }) => {
+const Pagination = ({
+  certTotalPage,
+  isSearchMode,
+}: {
+  certTotalPage: number;
+  isSearchMode: boolean;
+}) => {
   const { page, setPage } = pageStore();
+  const { searchedPage, setSearchedPage } = searchedPageStore();
+  const currentPage = isSearchMode ? searchedPage : page;
+  const setCurrentPage = isSearchMode ? setSearchedPage : setPage;
+
+  const pageSize = 10;
   const pageArr = [];
-  for (let index = 0; index < certTotalPage; index++) {
+  const firstPage = Math.floor(currentPage / pageSize) * pageSize;
+  const lastPage = Math.min(firstPage + pageSize, certTotalPage);
+  for (let index = firstPage; index < lastPage; index++) {
     pageArr.push(index);
   }
 
-  const prevPage = (page: number) => {
-    const prev = Math.max(page - 1, 0);
-    setPage(prev);
+  const prevPage = (currentPage: number) => {
+    const prev = Math.max(currentPage - 1, 0);
+    setCurrentPage(prev);
   };
 
-  const nextPage = (page: number) => {
-    const next = Math.min(page + 1, certTotalPage - 1);
-    setPage(next);
+  const nextPage = (currentPage: number) => {
+    const next = Math.min(currentPage + 1, certTotalPage - 1);
+    setCurrentPage(next);
   };
 
   return (
     <div className="page">
-      <ArrowLeft className="page-arrow-button" onClick={() => prevPage(page)} />
+      <ArrowLeft className="page-arrow-button" onClick={() => prevPage(currentPage)} />
       {pageArr.map((item, index) => (
         <div
           key={`page-${index}`}
-          className={`page-number ${item === page ? 'active' : ''}`}
-          onClick={() => setPage(item)}
+          className={`page-number ${item === currentPage ? 'active' : ''}`}
+          onClick={() => setCurrentPage(item)}
         >
           {item + 1}
         </div>
       ))}
-      <ArrowRight className="page-arrow-button" onClick={() => nextPage(page)} />
+      <ArrowRight className="page-arrow-button" onClick={() => nextPage(currentPage)} />
     </div>
   );
 };

--- a/src/components/SearchBox.tsx
+++ b/src/components/SearchBox.tsx
@@ -1,10 +1,10 @@
 import Search from '@icon/icon-search.svg?react';
 import { useCertService } from '@feature/Certification/useCertService.ts';
-import certStore from '@store/certification/certStore';
+import { searchWordStore } from '@store/certification/certStore';
 import './style/searchBox.scss';
 
 const SearchBox = ({ isTitle }: { isTitle: boolean }) => {
-  const { searchWord, setSearchWord } = certStore();
+  const { searchWord, setSearchWord } = searchWordStore();
   const { moveToCertByName } = useCertService();
 
   return (

--- a/src/components/style/cancelButton.scss
+++ b/src/components/style/cancelButton.scss
@@ -6,4 +6,5 @@
   font-size: 16px;
   color: black;
   background-color: white;
+  cursor: pointer;
 }

--- a/src/components/style/confirmButton.scss
+++ b/src/components/style/confirmButton.scss
@@ -6,4 +6,5 @@
   font-size: 16px;
   color: white;
   background-color: #4f72f3;
+  cursor: pointer;
 }

--- a/src/features/Certification/useCertService.ts
+++ b/src/features/Certification/useCertService.ts
@@ -2,8 +2,8 @@ import { useNavigate } from 'react-router-dom';
 import { useGetCert, useGetCertDetail, useGetCertRecommend } from '../../api';
 import { useGetSearchCert } from '@api/queries/useCertQuery.ts';
 
-const useCertList = (id: number, page: number) => {
-  const { data: cert } = useGetCert(id, page, 10);
+const useCertList = (isMain: boolean, id: number, page: number) => {
+  const { data: cert } = useGetCert(isMain, id, page, 10);
   return cert;
 };
 

--- a/src/features/Certification/useCertService.ts
+++ b/src/features/Certification/useCertService.ts
@@ -12,8 +12,8 @@ const useCertDetail = (id: number) => {
   return certDetail;
 };
 
-const useCertSearch = (name?: string) => {
-  const { data: searchedCert } = useGetSearchCert(name);
+const useCertSearch = (name: string, page: number) => {
+  const { data: searchedCert } = useGetSearchCert(name, page, 10);
   return searchedCert;
 };
 

--- a/src/features/MailingService/useMailingService.ts
+++ b/src/features/MailingService/useMailingService.ts
@@ -23,9 +23,12 @@ const useAddUserMailing = (certificationId: number) => {
 };
 
 const useDeleteUserMailing = (mailingsId: number[]) => {
+  const { refetch: refetchMailing } = useGetMailing(0, 2);
+
   return useDeleteMailing(mailingsId, {
     onSuccess: () => {
       toast.success(TOAST_MESSAGE.SUCCESS.DELETE_MAILING);
+      refetchMailing();
     },
     onError: (error: unknown) => {
       const errorMessage =

--- a/src/features/MyCalendar/useCalendarService.ts
+++ b/src/features/MyCalendar/useCalendarService.ts
@@ -25,9 +25,12 @@ const useAddUserCalendar = (certificationId: number) => {
 };
 
 const useDeleteUserCalendar = (certificationId: number) => {
+  const { refetch: refetchCalendar } = useGetCalendar();
+
   return useDeleteCalendar(certificationId, {
     onSuccess: () => {
       toast.success(TOAST_MESSAGE.SUCCESS.DELETE_CALENDAR);
+      refetchCalendar();
     },
     onError: (error: unknown) => {
       const errorMessage =

--- a/src/features/User/useUserService.ts
+++ b/src/features/User/useUserService.ts
@@ -15,15 +15,13 @@ const useUserData = () => {
   return user;
 };
 
-const useRefreshUserData = () => {
-  const { refetch: refetchUser } = useGetUser();
-  return refetchUser;
-};
-
 const useChangeUserNick = (nickname: string) => {
+  const { refetch: refetchUser } = useGetUser();
+
   return usePatchUserNick(nickname, {
     onSuccess: () => {
       toast.success(TOAST_MESSAGE.SUCCESS.CHANGE_NICKNAME);
+      refetchUser();
     },
     onError: (error: unknown) => {
       const errorMessage =
@@ -35,9 +33,12 @@ const useChangeUserNick = (nickname: string) => {
 };
 
 const useChangeUserEmail = (email: string) => {
+  const { refetch: refetchUser } = useGetUser();
+
   return usePatchUserEmail(email, {
     onSuccess: () => {
       toast.success(TOAST_MESSAGE.SUCCESS.CHANGE_EMAIL);
+      refetchUser();
     },
     onError: (error: unknown) => {
       const errorMessage =
@@ -49,9 +50,12 @@ const useChangeUserEmail = (email: string) => {
 };
 
 const useChangeUserInterest = (categoryIds: number[]) => {
+  const { refetch: refetchUser } = useGetUser();
+
   return usePatchUserInterest(categoryIds, {
     onSuccess: () => {
       toast.success(TOAST_MESSAGE.SUCCESS.CHANGE_INTEREST);
+      refetchUser();
     },
     onError: (error: unknown) => {
       const errorMessage =
@@ -63,7 +67,12 @@ const useChangeUserInterest = (categoryIds: number[]) => {
 };
 
 const useChangeMailingStatus = () => {
+  const { refetch: refetchUser } = useGetUser();
+
   return usePatchMailingService({
+    onSuccess: () => {
+      refetchUser();
+    },
     onError: (error: unknown) => {
       const errorMessage =
         (error as AxiosError<{ message: string }>)?.response?.data?.message ||
@@ -74,9 +83,12 @@ const useChangeMailingStatus = () => {
 };
 
 const useDeleteUserData = () => {
+  const { refetch: refetchUser } = useGetUser();
+
   return useDeleteUser({
     onSuccess: () => {
       toast.success(TOAST_MESSAGE.SUCCESS.DELETE_USER);
+      refetchUser();
     },
     onError: (error: unknown) => {
       const errorMessage =
@@ -89,7 +101,6 @@ const useDeleteUserData = () => {
 
 export {
   useUserData,
-  useRefreshUserData,
   useChangeUserNick,
   useChangeUserEmail,
   useChangeUserInterest,

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -1,8 +1,8 @@
 import { Header, Container, Footer } from './pages';
-import { useRefreshTokenInterceptor } from './common/utils/session';
+// import { useRefreshTokenInterceptor } from './common/utils/session';
 
 const Home = () => {
-  useRefreshTokenInterceptor();
+  // useRefreshTokenInterceptor();
 
   return (
     <>

--- a/src/home.tsx
+++ b/src/home.tsx
@@ -1,6 +1,9 @@
 import { Header, Container, Footer } from './pages';
+import { useRefreshTokenInterceptor } from './common/utils/session';
 
 const Home = () => {
+  useRefreshTokenInterceptor();
+
   return (
     <>
       <Header />

--- a/src/pages/CertSearch/View/CertCardListView.tsx
+++ b/src/pages/CertSearch/View/CertCardListView.tsx
@@ -3,11 +3,12 @@ import { useSearchParams } from 'react-router-dom';
 import CertificateCard from '@component/CertificateCard.tsx';
 import Pagination from '@component/Pagination';
 import { useCertList, useCertSearch } from '@feature/Certification/useCertService.ts';
-import pageStore from '@store/page/pageStore';
+import { pageStore, searchedPageStore } from '@store/page/pageStore';
 import '../style/certCardListView.scss';
 
 const CertCardListView = () => {
   const { page, setPage } = pageStore();
+  const { searchedPage, setSearchedPage } = searchedPageStore();
   const [searchParams] = useSearchParams();
   const [search, setSearch] = useState('');
   const categoryId = Number(
@@ -20,26 +21,33 @@ const CertCardListView = () => {
     setSearch(searchParams.get('search') ?? '');
   }, [searchParams]);
 
+  const isSearchMode = searchParams.get('search') !== null;
   const cert = useCertList(categoryId, page);
   const certData = cert?.data?.content ?? [];
   const certTotalPage = cert?.data?.totalPages ?? 0;
-  const searchedCert = useCertSearch(search);
+  const searchedCert = useCertSearch(search, searchedPage);
   const searchedCertData = searchedCert?.data?.content ?? [];
-  const searchedCertTotalPage = cert?.data?.totalPages ?? 0;
+  const searchedCertTotalPage = searchedCert?.data?.totalPages ?? 0;
 
   useEffect(() => {
     if (certTotalPage === 0 || certTotalPage > 0) {
       setPage(0);
+    }
+    if (searchedCertTotalPage === 0 || searchedCertTotalPage > 0) {
+      setSearchedPage(0);
     }
   }, [categoryId]);
 
   return (
     <>
       <div className="cert-cardList-group">
-        <CertificateCard data={searchedCertData.length === 0 ? certData : searchedCertData} />
+        <CertificateCard data={isSearchMode ? searchedCertData : certData} />
       </div>
       {(certTotalPage > 0 || searchedCertTotalPage > 0) && (
-        <Pagination certTotalPage={certTotalPage || searchedCertTotalPage} />
+        <Pagination
+          certTotalPage={isSearchMode ? searchedCertTotalPage : certTotalPage}
+          isSearchMode={isSearchMode}
+        />
       )}
     </>
   );

--- a/src/pages/CertSearch/View/CertCardListView.tsx
+++ b/src/pages/CertSearch/View/CertCardListView.tsx
@@ -4,6 +4,7 @@ import CertificateCard from '@component/CertificateCard.tsx';
 import Pagination from '@component/Pagination';
 import { useCertList, useCertSearch } from '@feature/Certification/useCertService.ts';
 import { pageStore, searchedPageStore } from '@store/page/pageStore';
+import { isMainCategoryStore } from '@store/certification/certStore.ts';
 import '../style/certCardListView.scss';
 
 const CertCardListView = () => {
@@ -11,6 +12,7 @@ const CertCardListView = () => {
   const { searchedPage, setSearchedPage } = searchedPageStore();
   const [searchParams] = useSearchParams();
   const [search, setSearch] = useState('');
+  const { isMainCategory } = isMainCategoryStore();
   const categoryId = Number(
     searchParams.get('subCategoryId')
       ? searchParams.get('subCategoryId')
@@ -22,7 +24,7 @@ const CertCardListView = () => {
   }, [searchParams]);
 
   const isSearchMode = searchParams.get('search') !== null;
-  const cert = useCertList(categoryId, page);
+  const cert = useCertList(isMainCategory, categoryId, page);
   const certData = cert?.data?.content ?? [];
   const certTotalPage = cert?.data?.totalPages ?? 0;
   const searchedCert = useCertSearch(search, searchedPage);

--- a/src/pages/Login/View/SocialLoginView.tsx
+++ b/src/pages/Login/View/SocialLoginView.tsx
@@ -1,4 +1,4 @@
-// import Naver from '@icon/SNS/icon-naver.svg?react';
+import Naver from '@icon/SNS/icon-naver.svg?react';
 import Kakao from '@icon/SNS/icon-kakao.svg?react';
 import Google from '@icon/SNS/icon-google.svg?react';
 import '../style/socialLoginView.scss';
@@ -15,12 +15,12 @@ const SocialLoginView = () => {
         <div className="socialLogin-title2">로그인을 하면 자격증을 추천해드릴게요!</div>
       </div>
       <div className="socialLogin-button-group">
-        {/* <div className="socialLogin-button" onClick={() => login('naver')}>
+        <div className="socialLogin-button" onClick={() => login('naver')}>
           <div className="socialLogin-text">
             <Naver />
             네이버 로그인
           </div>
-        </div> */}
+        </div>
         <div className="socialLogin-button" onClick={() => login('kakao')}>
           <div className="socialLogin-text">
             <Kakao />

--- a/src/pages/Login/style/socialLoginView.scss
+++ b/src/pages/Login/style/socialLoginView.scss
@@ -41,6 +41,7 @@
       width: 100%;
       height: 100%;
       box-shadow: 0 0 4px rgba(0, 0, 0, 0.1);
+      cursor: pointer;
 
       .socialLogin-text {
         display: flex;

--- a/src/pages/MainPage/MainPageContainer.tsx
+++ b/src/pages/MainPage/MainPageContainer.tsx
@@ -2,10 +2,10 @@ import { useEffect } from 'react';
 import MenuBarView from './View/MenuBarView.tsx';
 import RecommendCertView from './View/RecommendCertView.tsx';
 import SearchBox from '@component/SearchBox.tsx';
-import certStore from '@store/certification/certStore.ts';
+import { searchWordStore } from '@store/certification/certStore.ts';
 
 const MainPageContainer = () => {
-  const { setSearchWord } = certStore();
+  const { setSearchWord } = searchWordStore();
 
   useEffect(() => {
     setSearchWord('');

--- a/src/pages/MainPage/View/MenuBarView.tsx
+++ b/src/pages/MainPage/View/MenuBarView.tsx
@@ -12,7 +12,7 @@ const MenuBarView = () => {
   };
   const defaultCategory = useDefaultCategory();
   const moreCategory = useMoreCategory();
-  const { moveToCertById } = useCertService();
+  const { moveToCertById, moveToCertByName } = useCertService();
   const defaultCategoryData: ICategoryDataTypes[] | undefined = defaultCategory?.data;
   const moreCategoryData: ICategoryDataTypes[] | undefined = moreCategory?.data;
 
@@ -23,6 +23,9 @@ const MenuBarView = () => {
   return (
     <div className="menuBar-view">
       <div className="menuBar">
+        <div className="total-certInfo-button" onClick={() => moveToCertByName('')}>
+          전체보기
+        </div>
         <div className="menu-button">
           <div className="menu-button-box">
             {defaultCategoryData

--- a/src/pages/MainPage/View/MenuBarView.tsx
+++ b/src/pages/MainPage/View/MenuBarView.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import FieldButton from '@component/FieldButton.tsx';
 import { useCertService } from '@feature/Certification/useCertService';
 import { useDefaultCategory, useMoreCategory } from '@feature/Category/useCategoryService.ts';
+import { isMainCategoryStore } from '@store/certification/certStore.ts';
 import { ICategoryDataTypes } from '@type/category.ts';
 import '../style/menuBarView.scss';
 
@@ -10,6 +11,8 @@ const MenuBarView = () => {
   const handleIsDefault = () => {
     setIsDefault(!isDefault);
   };
+  const { setIsMainCategory } = isMainCategoryStore();
+
   const defaultCategory = useDefaultCategory();
   const moreCategory = useMoreCategory();
   const { moveToCertById, moveToCertByName } = useCertService();
@@ -18,6 +21,11 @@ const MenuBarView = () => {
 
   const handleMoveToCertById = (id: number, fieldName: string) => {
     if (id && fieldName) moveToCertById(id, fieldName, undefined);
+  };
+
+  const onClickFieldButton = (id: number, fieldName: string, isMainCategory: boolean) => {
+    handleMoveToCertById(id, fieldName);
+    setIsMainCategory(isMainCategory);
   };
 
   return (
@@ -33,7 +41,7 @@ const MenuBarView = () => {
               .map((item, index) => (
                 <FieldButton
                   key={index}
-                  clickEvent={() => handleMoveToCertById(item.id, item.name)}
+                  clickEvent={() => onClickFieldButton(item.id, item.name, true)}
                   fieldName={item.name}
                 />
               ))}
@@ -45,7 +53,7 @@ const MenuBarView = () => {
                 <FieldButton
                   key={index}
                   fieldName={item.name}
-                  clickEvent={() => handleMoveToCertById(item.id, item.name)}
+                  clickEvent={() => onClickFieldButton(item.id, item.name, true)}
                 />
               ))}
           </div>
@@ -59,7 +67,7 @@ const MenuBarView = () => {
                   <FieldButton
                     key={index}
                     fieldName={item.name}
-                    clickEvent={() => handleMoveToCertById(item.id, item.name)}
+                    clickEvent={() => onClickFieldButton(item.id, item.name, false)}
                   />
                 ))}
             </div>
@@ -70,7 +78,7 @@ const MenuBarView = () => {
                   <FieldButton
                     key={index}
                     fieldName={item.name}
-                    clickEvent={() => handleMoveToCertById(item.id, item.name)}
+                    clickEvent={() => onClickFieldButton(item.id, item.name, false)}
                   />
                 ))}
             </div>

--- a/src/pages/MainPage/style/menuBarView.scss
+++ b/src/pages/MainPage/style/menuBarView.scss
@@ -8,7 +8,7 @@
   .menuBar {
     width: 100%;
     margin: 64px 0;
-    padding: 64px 220px;
+    padding: 20px 220px 64px 220px;
     background: linear-gradient(180deg, #eaf0ff 0%, #ffffff 100%);
 
     .menu-button {
@@ -43,6 +43,18 @@
       margin-top: 16px;
       cursor: pointer;
 
+      &:hover {
+        color: style.$hover-blue;
+      }
+    }
+
+    .total-certInfo-button {
+      display: flex;
+      justify-content: center;
+      margin-bottom: 16px;
+      cursor: pointer;
+      font-size: 13px;
+      color: style.$primary-blue;
       &:hover {
         color: style.$hover-blue;
       }

--- a/src/pages/MyPage/View/AccountManageView.tsx
+++ b/src/pages/MyPage/View/AccountManageView.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Alert from '@component/Alert.tsx';
 import ArrowUp from '@icon/icon-arrow-up.svg?react';
 import ArrowDown from '@icon/icon-arrow-down.svg?react';
@@ -16,6 +16,7 @@ import '../style/accountManageView.scss';
 const AccountManageView = ({ data }: IUserDataProps) => {
   const [accountManageVisible, setAccountManageVisible] = useState(true);
   const [deleteUserAlertVisible, setDeleteUserAlertVisible] = useState(false);
+  const [isActiveMailing, setIsActiveMailing] = useState(false);
   const onVisibleAccountManageClick = () => {
     setAccountManageVisible(!accountManageVisible);
   };
@@ -25,6 +26,12 @@ const AccountManageView = ({ data }: IUserDataProps) => {
 
   const { mutate: changeMailingStatus } = useChangeMailingStatus();
   const { mutate: deleteUserData } = useDeleteUserData();
+
+  useEffect(() => {
+    if (data) {
+      setIsActiveMailing(data.status === 'ACTIVE');
+    }
+  }, [data]);
 
   return (
     <div id="account-manage" className="account-manage">
@@ -41,7 +48,7 @@ const AccountManageView = ({ data }: IUserDataProps) => {
           <div className="mailing-service-interruption">
             <div className="mailing-service-interruption__text">메일링 서비스 일시 중단</div>
             <div>
-              {data?.status === 'ACTIVE' ? (
+              {isActiveMailing ? (
                 <div className="mailing-service-interruption__toggle">
                   ON
                   <ToggleON data-cy="changeMailingStatus" onClick={() => changeMailingStatus()} />

--- a/src/pages/MyPage/View/MenuContentView.tsx
+++ b/src/pages/MyPage/View/MenuContentView.tsx
@@ -1,25 +1,14 @@
 import MyProfileView from './MyProfileView.tsx';
 import MailingServiceView from './MailingServiceView.tsx';
 import AccountManageView from './AccountManageView.tsx';
-import { useUserData, useRefreshUserData } from '@feature/User/useUserService.ts';
+import { useUserData } from '@feature/User/useUserService.ts';
 import { IUserData } from '@type/user.ts';
 import '../style/menuContentView.scss';
-import { useEffect } from 'react';
 
 const MenuContentView = () => {
   const user = useUserData();
   const userData: IUserData | undefined = user?.data;
-  const refetchUser = useRefreshUserData();
 
-  useEffect(() => {
-    refetchUser();
-  }, [
-    userData?.profileImageUrl,
-    userData?.nickname,
-    userData?.email,
-    userData?.interests,
-    userData?.status,
-  ]);
   return (
     <div className="menu-content">
       <MyProfileView data={userData} />

--- a/src/pages/MyPage/View/MyProfileView.tsx
+++ b/src/pages/MyPage/View/MyProfileView.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import ArrowDown from '@icon/icon-arrow-down.svg?react';
 import ArrowUp from '@icon/icon-arrow-up.svg?react';
 import FieldButton from '@component/FieldButton.tsx';
 import CheckFavoriteField from './CheckFavoriteField.tsx';
 import { cancelInterestMessage, confirmInterestMessage } from '../Messages/buttonMessages.ts';
-import { useChangeUserNick, useChangeUserEmail } from '@feature/User/useUserService.ts';
+import { useChangeUserNick } from '@feature/User/useUserService.ts';
 import { IUserDataProps } from '@type/user.ts';
 import '../style/myProfileView.scss';
 
@@ -21,7 +21,14 @@ const MyProfileView = ({ data }: IUserDataProps) => {
   };
 
   const { mutate: changeUserNick } = useChangeUserNick(nickname);
-  const { mutate: changeUserEmail } = useChangeUserEmail(email);
+  // const { mutate: changeUserEmail } = useChangeUserEmail(email);
+
+  useEffect(() => {
+    if (data) {
+      setNickname(data.nickname || '');
+      setEmail(data.email || '');
+    }
+  }, [data]);
 
   return (
     <>
@@ -46,7 +53,7 @@ const MyProfileView = ({ data }: IUserDataProps) => {
                 <div className="my-profile-info-box__group">
                   <input
                     className="my-profile-info-box__group__input"
-                    value={data?.nickname}
+                    value={nickname}
                     onChange={(e) => setNickname(e.target.value)}
                   />
                   <button
@@ -63,16 +70,17 @@ const MyProfileView = ({ data }: IUserDataProps) => {
                 <div className="my-profile-info-box__group">
                   <input
                     className="my-profile-info-box__group__input"
-                    value={data?.email}
+                    value={email}
                     onChange={(e) => setEmail(e.target.value)}
                   />
-                  <button
+                  {/* <button
                     data-cy="changeUserEmail"
                     className="my-profile-info-box__group__button"
                     onClick={() => changeUserEmail()}
+                    disabled
                   >
                     저장
-                  </button>
+                  </button> */}
                 </div>
               </div>
               <div className="my-profile-interest-field">

--- a/src/pages/OAuthRedirect/OAuthRedirectContainer.tsx
+++ b/src/pages/OAuthRedirect/OAuthRedirectContainer.tsx
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import authStore from '@store/auth/authStore';
+import { accessTokenStore, refreshTokenStore } from '@store/auth/authStore';
 // import useAuthService from '@feature/Auth/useAuthService.ts';
 
 const OAuthRedirectContainer = () => {
   // const { loginService } = useAuthService();
+  const { setAccessToken } = accessTokenStore();
+  const { setRefreshToken } = refreshTokenStore();
 
   const navigate = useNavigate();
   const moveToMainPage = () => {
@@ -13,13 +15,12 @@ const OAuthRedirectContainer = () => {
   };
   const [searchParams] = useSearchParams();
   const accessTokenByURL = searchParams.get('accessToken');
-  console.log(accessTokenByURL);
-  const { accessToken, setAccessToken } = authStore();
+  const refreshTokenByURL = searchParams.get('refreshToken');
 
   useEffect(() => {
     if (accessTokenByURL) {
       setAccessToken(accessTokenByURL || '');
-      console.log(accessToken);
+      setRefreshToken(refreshTokenByURL || '');
       // loginService();
       moveToMainPage();
     }

--- a/src/stories/Pagination/Pagination.stories.ts
+++ b/src/stories/Pagination/Pagination.stories.ts
@@ -17,5 +17,6 @@ export default meta;
 export const Pagination10: Story = {
   args: {
     certTotalPage: 10,
+    isSearchMode: true,
   },
 };

--- a/src/stories/Pagination/Pagination.tsx
+++ b/src/stories/Pagination/Pagination.tsx
@@ -1,38 +1,51 @@
 import ArrowLeft from '@icon/icon-arrow-left.svg?react';
 import ArrowRight from '@icon/icon-arrow-right.svg?react';
-import pageStore from '@store/page/pageStore';
+import { pageStore, searchedPageStore } from '@store/page/pageStore';
 import './pagination.scss';
 
-const Pagination = ({ certTotalPage }: { certTotalPage: number }) => {
+const Pagination = ({
+  certTotalPage,
+  isSearchMode,
+}: {
+  certTotalPage: number;
+  isSearchMode: boolean;
+}) => {
   const { page, setPage } = pageStore();
+  const { searchedPage, setSearchedPage } = searchedPageStore();
+  const currentPage = isSearchMode ? searchedPage : page;
+  const setCurrentPage = isSearchMode ? setSearchedPage : setPage;
+
+  const pageSize = 10;
   const pageArr = [];
-  for (let index = 0; index < certTotalPage; index++) {
+  const firstPage = Math.floor(currentPage / pageSize) * pageSize;
+  const lastPage = Math.min(firstPage + pageSize, certTotalPage);
+  for (let index = firstPage; index < lastPage; index++) {
     pageArr.push(index);
   }
 
-  const prevPage = (page: number) => {
-    const prev = Math.max(page - 1, 0);
-    setPage(prev);
+  const prevPage = (currentPage: number) => {
+    const prev = Math.max(currentPage - 1, 0);
+    setCurrentPage(prev);
   };
 
-  const nextPage = (page: number) => {
-    const next = Math.min(page + 1, certTotalPage - 1);
-    setPage(next);
+  const nextPage = (currentPage: number) => {
+    const next = Math.min(currentPage + 1, certTotalPage - 1);
+    setCurrentPage(next);
   };
 
   return (
     <div className="page">
-      <ArrowLeft className="page-arrow-button" onClick={() => prevPage(page)} />
+      <ArrowLeft className="page-arrow-button" onClick={() => prevPage(currentPage)} />
       {pageArr.map((item, index) => (
         <div
           key={`page-${index}`}
-          className={`page-number ${item === page ? 'active' : ''}`}
-          onClick={() => setPage(item)}
+          className={`page-number ${item === currentPage ? 'active' : ''}`}
+          onClick={() => setCurrentPage(item)}
         >
           {item + 1}
         </div>
       ))}
-      <ArrowRight className="page-arrow-button" onClick={() => nextPage(page)} />
+      <ArrowRight className="page-arrow-button" onClick={() => nextPage(currentPage)} />
     </div>
   );
 };


### PR DESCRIPTION
### :bell: 작업 개요
<!-- Fixes #[issue_number]를 작성해주세요. -->
#71 

### :construction: 문제 & 변경 이유
<!-- 이 코드에 어떤 문제가 있었는지, 변경하려는 이유를 작성해주세요. -->
콰르텟 팀원들과 함께 테스트한 잔여 이슈를 지속적으로 처리하려고 합니다.

### :hammer_and_wrench: 변경 내용
<!-- 주요 변경점을 작성해주세요. -->
- [x]  검색어가 없는 경우 전체 자격증 정보를 조회할 수 있도록 추가 & 페이지네이션 추가
- [x]  메인페이지의 카테고리 메뉴바에서 ‘전체보기’ 클릭 시 전체 자격증 조회 기능 추가
- [x]  카테고리별 자격증 조회 API 규격 수정으로 isMain Params 추가
- [x]  네이버 로그인 API 검수 승인되어 다시 주석 풀기
- [x]  로그인 상태에 따라 로그인, 로그아웃, 마이페이지, 내 캘린더 버튼 분기처리
- [x]  status code가 401일 경우 access token 만료 시 refresh token으로 access token을 재발급 받을 수 있도록 추가
- [x]  소셜 로그인 시 refresh token을 query parameter 통해 저장할 수 있도록 추가
- [x]  내 캘린더, 마이페이지에서 데이터 수정 시 데이터가 업데이트 되지 않는 현상 제거
- [x]  사용자 이메일을 수정할 수 없도록 ‘저장’ 버튼 제거
- [x]  ConfirmButton, CancelButton 컴포넌트에 cursor: pointer 추가

### :dart: 리뷰 포인트
<!-- 리뷰어 분들이 집중적으로 리뷰하고 싶은 내용을 작성해주세요. -->
useRefreshTokenInterceptor() 커스텀훅이 어느 위치에 있어야 좋을지 리뷰해주시면 좋을 것 같습니다!
